### PR TITLE
SR-02: Publisher delivery control (.main | .current)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,27 @@ class AsyncService {
     //     }).eraseToAnyPublisher()
     // }
 }
+
+// Delivery control for UI consumers
+class UIService {
+    // Deliver publisher events on the main queue
+    @AwaitlessPublisher(deliverOn: .main)
+    func loadUIData() async throws -> [Item] {
+        // Async implementation
+        return []
+    }
+    // Generates:
+    // func loadUIData() -> AnyPublisher<[Item], Error> {
+    //     Future({ promise in
+    //         Task() {
+    //             do { promise(.success(try await self.loadUIData())) }
+    //             catch { promise(.failure(error)) }
+    //         }
+    //     })
+    //     .receive(on: DispatchQueue.main) // delivery control
+    //     .eraseToAnyPublisher()
+    // }
+}
 ```
 
 ### Protocol Extensions with Default Implementations

--- a/Sources/AwaitlessCore/AwaitlessDelivery.swift
+++ b/Sources/AwaitlessCore/AwaitlessDelivery.swift
@@ -1,0 +1,14 @@
+//
+// Copyright (c) 2025 Daniel Bauke
+//
+
+import Foundation
+
+/// Controls delivery context for generated publishers.
+public enum AwaitlessDelivery {
+    /// Do not modify delivery; emit on the Task's context.
+    case current
+    /// Deliver on the main queue (UI‑friendly).
+    case main
+}
+

--- a/Sources/AwaitlessKit/AwaitlessKitMacros.swift
+++ b/Sources/AwaitlessKit/AwaitlessKitMacros.swift
@@ -16,6 +16,7 @@ public macro Awaitless(
 @attached(peer, names: arbitrary)
 public macro AwaitlessPublisher(
     prefix: String = "",
+    deliverOn: AwaitlessDelivery = .current,
     _ availability: AwaitlessAvailability? = nil) = #externalMacro(
     module: "AwaitlessKitMacros",
     type: "AwaitlessAttachedMacro")

--- a/Sources/AwaitlessKitMacros/AwaitlessAttachedMacro.swift
+++ b/Sources/AwaitlessKitMacros/AwaitlessAttachedMacro.swift
@@ -160,7 +160,8 @@ public struct AwaitlessAttachedMacro: PeerMacro {
             from: funcDecl,
             prefix: prefix,
             outputType: outputType,
-            availability: availability)
+            availability: availability,
+            delivery: delivery)
         return [generatedDecl]
     }
 
@@ -219,7 +220,8 @@ public struct AwaitlessAttachedMacro: PeerMacro {
         from funcDecl: FunctionDeclSyntax,
         prefix: String,
         outputType: AwaitlessOutputType,
-        availability: AwaitlessAvailability?)
+        availability: AwaitlessAvailability?,
+        delivery: AwaitlessDelivery)
         -> DeclSyntax
     {
         switch outputType {

--- a/Sources/AwaitlessKitMacros/AwaitlessAttachedMacro.swift
+++ b/Sources/AwaitlessKitMacros/AwaitlessAttachedMacro.swift
@@ -60,6 +60,7 @@ public struct AwaitlessAttachedMacro: PeerMacro {
         // Default output type depends on attribute name: AwaitlessPublisher => .publisher, else .sync
         var outputType: AwaitlessOutputType = (attrName == "AwaitlessPublisher") ? .publisher : .sync
         var availability: AwaitlessAvailability? = nil
+        var delivery: AwaitlessDelivery = .current
 
         if case let .argumentList(arguments) = node.arguments {
             // Check for prefix parameter
@@ -97,6 +98,18 @@ public struct AwaitlessAttachedMacro: PeerMacro {
                         #endif
                     } else if memberAccess.declName.baseName.text == "sync" {
                         outputType = .sync
+                    }
+                }
+
+                // Parse delivery option for @AwaitlessPublisher
+                if attrName == "AwaitlessPublisher",
+                   labeledExpr.label?.text == "deliverOn",
+                   let memberAccess = labeledExpr.expression.as(MemberAccessExprSyntax.self)
+                {
+                    if memberAccess.declName.baseName.text == "main" {
+                        delivery = .main
+                    } else {
+                        delivery = .current
                     }
                 }
             }
@@ -220,7 +233,8 @@ public struct AwaitlessAttachedMacro: PeerMacro {
             return DeclSyntax(createPublisherFunction(
                 from: funcDecl,
                 prefix: prefix,
-                availability: availability))
+                availability: availability,
+                delivery: delivery))
             #else
             // This should never be reached due to earlier validation,
             // but provide a fallback just in case
@@ -290,8 +304,8 @@ public struct AwaitlessAttachedMacro: PeerMacro {
     private static func createPublisherFunction(
         from funcDecl: FunctionDeclSyntax,
         prefix: String,
-
-        availability: AwaitlessAvailability?)
+        availability: AwaitlessAvailability?,
+        delivery: AwaitlessDelivery)
         -> FunctionDeclSyntax
     {
         let originalFuncName = funcDecl.name.text
@@ -322,7 +336,8 @@ public struct AwaitlessAttachedMacro: PeerMacro {
             originalFuncName: originalFuncName,
             parameters: funcDecl.signature.parameterClause.parameters,
             isThrowing: isThrowing,
-            returnType: returnTypeSyntax)
+            returnType: returnTypeSyntax,
+            delivery: delivery)
 
         // Create the new function signature
         let newSignature = FunctionSignatureSyntax(
@@ -471,7 +486,8 @@ public struct AwaitlessAttachedMacro: PeerMacro {
         originalFuncName: String,
         parameters: FunctionParameterListSyntax,
         isThrowing: Bool,
-        returnType: TypeSyntax?)
+        returnType: TypeSyntax?,
+        delivery: AwaitlessDelivery)
         -> CodeBlockSyntax
     {
         // Map parameters from the original function to argument expressions
@@ -653,10 +669,38 @@ public struct AwaitlessAttachedMacro: PeerMacro {
             },
             rightParen: .rightParenToken())
         
+        // Optionally add .receive(on: DispatchQueue.main)
+        let baseForErase: ExprSyntax = {
+            switch delivery {
+            case .main:
+                let receiveCall = FunctionCallExprSyntax(
+                    calledExpression: MemberAccessExprSyntax(
+                        base: ExprSyntax(publisherCall),
+                        period: .periodToken(),
+                        name: .identifier("receive")),
+                    leftParen: .leftParenToken(),
+                    arguments: LabeledExprListSyntax {
+                        LabeledExprSyntax(
+                            label: .identifier("on"),
+                            colon: .colonToken(),
+                            expression: ExprSyntax(
+                                MemberAccessExprSyntax(
+                                    base: DeclReferenceExprSyntax(baseName: .identifier("DispatchQueue")),
+                                    period: .periodToken(),
+                                    name: .identifier("main")))
+                        )
+                    },
+                    rightParen: .rightParenToken())
+                return ExprSyntax(receiveCall)
+            case .current:
+                return ExprSyntax(publisherCall)
+            }
+        }()
+
         // Add .eraseToAnyPublisher()
         let erasedPublisher = FunctionCallExprSyntax(
             calledExpression: MemberAccessExprSyntax(
-                base: ExprSyntax(publisherCall),
+                base: baseForErase,
                 period: .periodToken(),
                 name: .identifier("eraseToAnyPublisher")),
             leftParen: .leftParenToken(),


### PR DESCRIPTION
Closes #3\n\nAdds delivery control to @AwaitlessPublisher via . When  is set, the generated publisher appends  before .\n\nChanges\n- Core: new  enum\n- Macro: parse  and conditionally add \n- Tests: added snapshot for main delivery\n- Docs: README example covering \n\nNotes\n- Default remains  (no ).\n- Combine-only feature; behavior unchanged when Combine unavailable.\n