### PR TITLE
SR-03: Completion macro

### DIFF
--- a/Sources/AwaitlessCore/AwaitlessOutputType.swift
+++ b/Sources/AwaitlessCore/AwaitlessOutputType.swift
@@ -11,4 +11,7 @@ public enum AwaitlessOutputType {
     /// Generates a Combine publisher instead of a synchronous function.
     /// Requires Combine framework to be available.
     case publisher
+    /// Generates a completion-handler based function that reports
+    /// results via a `Result<Success, Error>` in a trailing completion.
+    case completion
 }

--- a/Sources/AwaitlessKit/AwaitlessKitMacros.swift
+++ b/Sources/AwaitlessKit/AwaitlessKitMacros.swift
@@ -21,6 +21,14 @@ public macro AwaitlessPublisher(
     module: "AwaitlessKitMacros",
     type: "AwaitlessAttachedMacro")
 
+// Completion-only entry point (SR-03)
+@attached(peer, names: arbitrary)
+public macro AwaitlessCompletion(
+    prefix: String = "",
+    _ availability: AwaitlessAvailability? = nil) = #externalMacro(
+    module: "AwaitlessKitMacros",
+    type: "AwaitlessAttachedMacro")
+
 @freestanding(expression)
 public macro awaitless<T>(_ expression: T) -> T = #externalMacro(
     module: "AwaitlessKitMacros",

--- a/Tests/AwaitlessKitTests/AwaitlessCompletionTests.swift
+++ b/Tests/AwaitlessKitTests/AwaitlessCompletionTests.swift
@@ -1,0 +1,106 @@
+//
+// Copyright (c) 2025 Daniel Bauke
+//
+
+@testable import AwaitlessKit
+import AwaitlessKitMacros
+import MacroTesting
+import Testing
+
+@Suite(.macros(["Awaitless": AwaitlessAttachedMacro.self, "AwaitlessCompletion": AwaitlessAttachedMacro.self], record: .missing))
+struct AwaitlessCompletionTests {
+    @Test("Expand completion wrapper for throwing function with return")
+    func completionThrowing() {
+        assertMacro {
+            """
+            @AwaitlessCompletion
+            func fetch() async throws -> String {
+                try await Task.sleep(nanoseconds: 1)
+                return "OK"
+            }
+            """
+        } expansion: {
+            """
+            func fetch() async throws -> String {
+                try await Task.sleep(nanoseconds: 1)
+                return "OK"
+            }
+
+            func fetch(completion: @escaping (Result<String, Error>) -> Void) {
+                Task() {
+                    do {
+                        let result = try await self.fetch()
+                        completion(.success(result))
+                    } catch {
+                        completion(.failure(error))
+                    }
+                }
+            }
+            """
+        }
+    }
+
+    @Test("Expand completion wrapper for non-throwing function with return")
+    func completionNonThrowing() {
+        assertMacro {
+            """
+            @AwaitlessCompletion
+            func data() async -> Int { 1 }
+            """
+        } expansion: {
+            """
+            func data() async -> Int { 1 }
+
+            func data(completion: @escaping (Result<Int, Error>) -> Void) {
+                Task() {
+                    let result = await self.data()
+                    completion(.success(result))
+                }
+            }
+            """
+        }
+    }
+
+    @Test("Expand completion wrapper for void-returning function")
+    func completionVoid() {
+        assertMacro {
+            """
+            @AwaitlessCompletion
+            func ping() async { }
+            """
+        } expansion: {
+            """
+            func ping() async { }
+
+            func ping(completion: @escaping (Result<Void, Error>) -> Void) {
+                Task() {
+                    await self.ping()
+                    completion(.success(()))
+                }
+            }
+            """
+        }
+    }
+
+    @Test("Expand completion wrapper with prefix")
+    func completionWithPrefix() {
+        assertMacro {
+            """
+            @AwaitlessCompletion(prefix: "c_")
+            func calc() async -> Int { 2 }
+            """
+        } expansion: {
+            """
+            func calc() async -> Int { 2 }
+
+            func c_calc(completion: @escaping (Result<Int, Error>) -> Void) {
+                Task() {
+                    let result = await self.calc()
+                    completion(.success(result))
+                }
+            }
+            """
+        }
+    }
+}
+


### PR DESCRIPTION
Implements SR-03 completion-based peer generation via AwaitlessCompletion.

- Adds public macro entrypoint AwaitlessCompletion
- Extends AwaitlessOutputType with .completion
- Implements completion wrapper generation in AwaitlessAttachedMacro
- Focused tests (AwaitlessCompletionTests) pass locally

Labels: sr-03, macros, feature